### PR TITLE
Update GitHub Actions workflows to use node20

### DIFF
--- a/.github/workflows/tf-drift.yml
+++ b/.github/workflows/tf-drift.yml
@@ -30,11 +30,11 @@ jobs:
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Install the latest version of the Terraform CLI
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@v3
       with:
         terraform_wrapper: false
 
@@ -61,7 +61,7 @@ jobs:
         
     # Save plan to artifacts  
     - name: Publish Terraform Plan
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tfplan
         path: tfplan
@@ -93,7 +93,7 @@ jobs:
     # If changes are detected, create a new issue
     - name: Publish Drift Report
       if: steps.tf-plan.outputs.exitcode == 2
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       env:
         SUMMARY: "${{ steps.tf-plan-string.outputs.summary }}"
       with:
@@ -141,7 +141,7 @@ jobs:
     # If changes aren't detected, close any open drift issues
     - name: Publish Drift Report
       if: steps.tf-plan.outputs.exitcode == 0
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/tf-plan-apply.yml
+++ b/.github/workflows/tf-plan-apply.yml
@@ -33,11 +33,11 @@ jobs:
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Install the latest version of the Terraform CLI
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@v3
       with:
         terraform_wrapper: false
 
@@ -69,7 +69,7 @@ jobs:
         
     # Save plan to artifacts  
     - name: Publish Terraform Plan
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tfplan
         path: tfplan
@@ -101,7 +101,7 @@ jobs:
     # If this is a PR post the changes
     - name: Push Terraform Output to PR
       if: github.ref != 'refs/heads/main'
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       env:
         SUMMARY: "${{ steps.tf-plan-string.outputs.summary }}"
       with:
@@ -125,11 +125,11 @@ jobs:
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@v3
 
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
@@ -137,7 +137,7 @@ jobs:
 
     # Download saved plan from artifacts  
     - name: Download Terraform Plan
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: tfplan
 

--- a/.github/workflows/tf-unit-tests.yml
+++ b/.github/workflows/tf-unit-tests.yml
@@ -39,7 +39,7 @@ jobs:
     # Upload results to GitHub Advanced Security
     - name: Upload SARIF file
       if: success() || failure()
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: results.sarif
         category: checkov

--- a/.github/workflows/tf-unit-tests.yml
+++ b/.github/workflows/tf-unit-tests.yml
@@ -11,11 +11,11 @@ jobs:
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@v3
 
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init

--- a/.github/workflows/tf-unit-tests.yml
+++ b/.github/workflows/tf-unit-tests.yml
@@ -3,6 +3,11 @@ name: 'Terraform Unit Tests'
 on:
   push:
 
+permissions:
+  security-events: write # Needed to upload-sarif
+  contents: read # Needed to clone repo
+  actions: read # Potentially needed for private repositories (see https://github.com/github/codeql-action/issues/2117)
+
 jobs:
   terraform-unit-tests:
     name: 'Terraform Unit Tests'

--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ To use these workflows in your environment several prerequisite steps are requir
     
 ## Additional Resources
 
-A companion article detailing how to use GitHub Actions to deploy to Azure using IaC can be found at the [DevOps Resource Center](). `TODO: add link`
+A companion article detailing how to use GitHub Actions to deploy to Azure using IaC can be found at the [DevOps Resource Center](https://learn.microsoft.com/devops/deliver/iac-github-actions). 


### PR DESCRIPTION
This pull request primarily includes updates to the versions of actions used in the GitHub workflow files, and an update to a link in the README file. The most important changes include upgrading the `actions/checkout`, `hashicorp/setup-terraform`, `actions/upload-artifact`, `actions/github-script`, `actions/download-artifact`, and `github/codeql-action/upload-sarif` actions to newer versions across multiple workflow files. Additionally, the `tf-unit-tests.yml` workflow file now includes permissions for `security-events`, `contents`, and `actions`. Lastly, a previously missing link in the README file has been added.